### PR TITLE
Post#comments を memcache にキャッシュ #1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,12 +51,12 @@ gem "less-rails"
 gem "twitter-bootstrap-rails"
 gem "jquery-ui-rails"
 gem "ransack", github: 'ernie/ransack', branch: "rails-4"
+gem "dalli"
 
 group :development do
   gem "i18n_generators", git: "git://github.com/amatsuda/i18n_generators.git"
   gem "better_errors"
   gem 'binding_of_caller'
-  gem 'meta_request'
   gem 'annotate'
 end
 
@@ -69,4 +69,8 @@ group :development, :test do
   gem 'ci_reporter'
   gem 'simplecov'
   gem 'simplecov-rcov'
+end
+
+group :test do
+  gem 'test_after_commit'  # to test after_commit
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,6 @@ GEM
     binding_of_caller (0.7.1)
       debug_inspector (>= 0.0.1)
     builder (3.1.4)
-    callsite (0.0.11)
     ci_reporter (1.8.4)
       builder (>= 2.1.2)
     coderay (1.0.9)
@@ -85,6 +84,7 @@ GEM
       execjs
     coffee-script-source (1.6.2)
     commonjs (0.2.6)
+    dalli (2.6.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.4)
     domain_name (0.5.11)
@@ -138,10 +138,6 @@ GEM
       nokogiri (~> 1.4)
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (>= 0.0.9, < 0.2)
-    meta_request (0.2.4)
-      callsite
-      rack-contrib
-      railties
     method_source (0.8.1)
     mime-types (1.23)
     minitest (4.7.4)
@@ -161,8 +157,6 @@ GEM
     pry-rails (0.3.0)
       pry (>= 0.9.10)
     rack (1.5.2)
-    rack-contrib (1.1.0)
-      rack (>= 0.9.1)
     rack-test (0.6.2)
       rack (>= 1.0)
     rails (4.0.0.beta1)
@@ -213,6 +207,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.7)
+    test_after_commit (0.2.0)
     therubyracer (0.11.4)
       libv8 (~> 3.11.8.12)
       ref
@@ -253,6 +248,7 @@ DEPENDENCIES
   binding_of_caller
   cancan!
   ci_reporter
+  dalli
   exception_notification!
   factory_girl_rails
   faker
@@ -263,7 +259,6 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   less-rails
-  meta_request
   pg
   pry-rails
   rails (= 4.0.0.beta1)
@@ -274,6 +269,7 @@ DEPENDENCIES
   simplecov-rcov
   spring
   sqlite3
+  test_after_commit
   therubyracer
   turbolinks
   twitter-bootstrap-rails

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,4 +17,9 @@ class Comment < ActiveRecord::Base
   validates :user, presence: true
   validates :post, presence: true
   validates :body, presence: true, length: 1..140
+
+  after_commit do
+    post.try(:flush_cache)
+    true
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,4 +18,24 @@ class Post < ActiveRecord::Base
   validates :user, presence: true
   validates :text, presence: true, length: 1..300
   validates :url, url_format: true
+
+  # memcache key (without timestamp)
+  def cache_key
+    if new_record?
+      "#{self.class.model_name.cache_key}/new"
+    else
+      "#{self.class.model_name.cache_key}/#{id}"
+    end
+  end
+
+  # returns the cached comments if comments are cached,
+  # otherwise gets comments from DB and caches and returns them
+  def cached_comments
+    Rails.cache.fetch([self, 'comments']) { comments.to_a }
+  end
+
+  # clear all cache belongs to self
+  def flush_cache
+    Rails.cache.delete([self, 'comments'])
+  end
 end

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -17,5 +17,5 @@
 
 %h2 コメント
 %ul
-  = render @post.comments
+  = render @post.cached_comments
 = link_to t('.new', :default => t("helpers.links.new")), new_post_comment_path(@post), :class => 'btn btn-primary'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,16 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application.
 Example::Application.initialize!
+
+# see https://github.com/mdesjardins/dalli/tree/#usage-with-passenger
+if defined?(PhusionPassenger)
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    # Reset Rails's object cache
+    # Only works with DalliStore
+    Rails.cache.reset if forked
+
+    # Reset Rails's session store
+    # If you know a cleaner way to find the session store instance, please let me know
+    ObjectSpace.each_object(ActionDispatch::Session::DalliStore) { |obj| obj.reset }
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,4 +24,6 @@ Example::Application.configure do
 
   # Debug mode disables concatenation and preprocessing of assets.
   config.assets.debug = true
+
+  config.cache_store = :dalli_store, 'localhost:11211'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,6 @@ Example::Application.configure do
         :exception_recipients => ENV['EXCEPTION_MAIL_TO'].split(',')
       }
   end
+
+  config.cache_store = :dalli_store, 'localhost:11211'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,4 +33,6 @@ Example::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  config.cache_store = :dalli_store, 'localhost:11211'
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -10,4 +10,54 @@ describe Post do
       expect{comments[1].reload}.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  describe '#cached_comments' do
+    before do
+      @post = FactoryGirl.create(:post)
+      @post.flush_cache
+      @comments = FactoryGirl.create_list(:comment, 2, post: @post).sort_by(&:id)
+    end
+    context 'before caching' do
+      it 'gets comments from DB' do
+        @post.should_receive(:comments).once
+        @post.cached_comments
+      end
+      it 'stores comments into cache' do
+        expect(Rails.cache.read([@post, 'comments'])).to be_blank
+        @post.cached_comments
+        expect(Rails.cache.read([@post, 'comments'])).to be_present
+      end
+    end
+    context 'after caching' do
+      before do
+        @post.cached_comments
+        @post = Post.find(@post.id)
+      end
+      it 'gets comments from cache' do
+        @post.should_receive(:comments).never
+        @post.cached_comments
+      end
+      it 'returns correct comments' do
+        expect(@post.cached_comments.sort_by(&:id)).to eq(@comments)
+      end
+
+      it "doesn't clear cache when updated" do
+        @post.updated_at = Time.now
+        @post.save
+        expect(Rails.cache.read([@post, 'comments'])).to be_present
+      end
+      it 'clears cache when another comment are added' do
+        FactoryGirl.create(:comment, post: @post)
+        expect(Rails.cache.read([@post, 'comments'])).to be_blank
+      end
+      it 'clears cache when one of the comments is destoryed' do
+        @comments[rand(@comments.size)].destroy
+        expect(Rails.cache.read([@post, 'comments'])).to be_blank
+      end
+      it 'clears cache when one of the comments is updated' do
+        @comments[rand(@comments.size)].update_attribute(:body, 'updated body')
+        expect(Rails.cache.read([@post, 'comments'])).to be_blank
+      end
+    end
+  end
 end


### PR DESCRIPTION
- https://github.com/heartrails/rails4-example/pull/23 を Rails.cache を直接使う方法で書き直しました
- meta_request gem が入っていると Rails.cache の動作がおかしくなったので外しています 
